### PR TITLE
fix: add trailing new line when writting to logger

### DIFF
--- a/support/bundle/bundle.go
+++ b/support/bundle/bundle.go
@@ -83,7 +83,7 @@ func (a *archive) Close() error {
 // Log writes the line to logger or to stdout if no logger was provided.
 func (options *Options) Log(line string, args ...interface{}) {
 	if options.LogOutput != nil {
-		fmt.Fprintf(options.LogOutput, line, args...) //nolint:errcheck
+		fmt.Fprintf(options.LogOutput, line+"\n", args...) //nolint:errcheck
 
 		return
 	}


### PR DESCRIPTION
When setting the bundle option `bundle.WithLogOutput(writer)`, all logs are being returned as one line:

```
time=2025-11-18T09:39:13Z level=debug msg="getting kubernetes nodes manifestsgetting pods manifests in kube-system namespacegetting system/controller-runtime service logsgetting system/dns-resolve-cache service logsinspecting controller runtime...
```

This change adds a trailing new line when sending the log to a logger in the same way as it's done for the `stdout`.
The logs are then displayed as expected:

```
time=2025-11-18T13:28:29Z level=debug msg="getting kubernetes nodes manifests"
time=2025-11-18T13:28:29Z level=debug msg="getting pods manifests in kube-system namespace"
time=2025-11-18T13:28:29Z level=debug msg="getting system/controller-runtime service logs"
time=2025-11-18T13:28:29Z level=debug msg="getting system/dns-resolve-cache service logs"
time=2025-11-18T13:28:29Z level=debug msg="inspecting controller runtime"
```
